### PR TITLE
Add Patient Context and Add Page Page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@lottiefiles/react-lottie-player": "^3.6.0",
         "@tailwindcss/vite": "^4.1.11",
         "ag-grid-react": "^34.1.1",
+        "nanoid": "^5.1.5",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "react-icons": "^5.5.0",
@@ -2871,9 +2872,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.5.tgz",
+      "integrity": "sha512-Ir/+ZpE9fDsNH0hQ3C68uyThDXzYcim2EqcZ8zn8Chtt1iylPT9xXJB0kPCnqzgcEGikO9RxSrh63MsmVCU7Fw==",
       "funding": [
         {
           "type": "github",
@@ -2882,10 +2883,10 @@
       ],
       "license": "MIT",
       "bin": {
-        "nanoid": "bin/nanoid.cjs"
+        "nanoid": "bin/nanoid.js"
       },
       "engines": {
-        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+        "node": "^18 || >=20"
       }
     },
     "node_modules/natural-compare": {
@@ -3038,6 +3039,24 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postcss/node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
     "node_modules/prelude-ls": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@lottiefiles/react-lottie-player": "^3.6.0",
     "@tailwindcss/vite": "^4.1.11",
     "ag-grid-react": "^34.1.1",
+    "nanoid": "^5.1.5",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-icons": "^5.5.0",

--- a/src/Pages/admin/AddPatientPage.jsx
+++ b/src/Pages/admin/AddPatientPage.jsx
@@ -1,10 +1,174 @@
-import React from 'react';
+import { useContext, useEffect, useState } from "react";
+import { PatientContext } from "../../contexts/PatientContext";
+import { nanoid } from 'nanoid';
+import { useNavigate } from "react-router-dom";
+
 
 const AddPatientPage = () => {
+  const {addPatient} = useContext(PatientContext);
+  const [firstName, setFirstName] = useState("");
+  const [lastName, setLastName] = useState("");
+  const [phoneNum, setphoneNum] = useState("");
+  const [emailAddress, setemailAddress] = useState("");
+  const [country, setCountry] = useState("");
+  const [city, setCity] = useState("");
+  const [street, setStreet] = useState("");
+  const [IdGenerator, setIdGenerator] = useState("");
+
+  const status = "Checked In";
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    setIdGenerator(nanoid(6));
+  },[])
+
+  const submitForm = (e) => {
+    e.preventDefault();
+
+    addPatient({
+      id: IdGenerator,
+      name: firstName + " " + lastName,
+      phoneNum: phoneNum,
+      emailAddress:emailAddress,
+      country: country,
+      city: city,
+      street: street,
+      currentStatus: status,
+      lastUpdated: new Date().toISOString()
+    })
+
+    navigate('/dashboard')
+  }
+
   return (
-    <div>
-      <h1 className="text-3xl font-bold">Admin: Add Patient Page</h1>
+      <>
+      <h1 className="text-4xl font-bold text-gray-800 mb-2 text-center p-6">Add New Patient</h1>
+      <div className="max-w-4xl mx-auto p-6 bg-white shadow-2xl rounded-2xl">
+      <form className="space-y-6" onSubmit={submitForm}>
+        {/* Row: First Name + Last Name */}
+        <div className="flex flex-wrap gap-6">
+          <div className="flex-1 min-w-[200px]">
+            <label htmlFor="firstName" className="block text-xl font-bold mb-3">First Name</label>
+            <input
+              required
+              type="text"
+              id="firstName"
+              value={firstName}
+              onChange={(e) => setFirstName(e.target.value)}
+              className="w-full border-2 border-gray-300 px-3 py-3 rounded-lg"
+            />
+          </div>
+
+          <div className="flex-1 min-w-[200px]">
+            <label htmlFor="lastName" className="block text-xl font-bold mb-3">Last Name</label>
+            <input
+              required
+              type="text"
+              id="lastName"
+              value={lastName}
+              onChange={(e) => setLastName(e.target.value)}
+              className="w-full border-2 border-gray-300 px-3 py-3 rounded-lg"
+            />
+          </div>
+        </div>
+
+        {/* Row: Phone + Email */}
+        <div className="flex flex-wrap gap-6">
+          <div className="flex-1 min-w-[200px]">
+            <label htmlFor="phoneNum" className="block text-xl font-bold mb-3">Telephone</label>
+            <input
+              required
+              type="text"
+              id="phoneNum"
+              value={phoneNum}
+              onChange={(e) => setphoneNum(e.target.value)}
+              className="w-full border-2 border-gray-300 px-3 py-3 rounded-lg"
+            />
+          </div>
+
+          <div className="flex-1 min-w-[200px]">
+            <label htmlFor="emailAddress" className="block text-xl font-bold mb-3">Email</label>
+            <input
+              required
+              type="email"
+              id="emailAddress"
+              value={emailAddress}
+              onChange={(e) => setemailAddress(e.target.value)}
+              className="w-full border-2 border-gray-300 px-3 py-3 rounded-lg"
+            />
+          </div>
+        </div>
+
+        {/* Row: Country + City + Street (3 fields on one line) */}
+        <div className="flex flex-wrap gap-6">
+          <div className="flex-1 min-w-[150px]">
+            <label htmlFor="country" className="block text-xl font-bold mb-3">Country</label>
+            <input
+              required
+              type="text"
+              id="country"
+              value={country}
+              onChange={(e) => setCountry(e.target.value)}
+              className="w-full border-2 border-gray-300 px-3 py-3 rounded-lg"
+            />
+          </div>
+
+          <div className="flex-1 min-w-[150px]">
+            <label htmlFor="city" className="block text-xl font-bold mb-3">City</label>
+            <input
+              required
+              type="text"
+              id="city"
+              value={city}
+              onChange={(e) => setCity(e.target.value)}
+              className="w-full border-2 border-gray-300 px-3 py-3 rounded-lg"
+            />
+          </div>
+
+          <div className="flex-1 min-w-[150px]">
+            <label htmlFor="street" className="block text-xl font-bold mb-3">Street</label>
+            <input
+              required
+              type="text"
+              id="street"
+              value={street}
+              onChange={(e) => setStreet(e.target.value)}
+              className="w-full border-2 border-gray-300 px-3 py-3 rounded-lg"
+            />
+          </div>
+        </div>
+
+        {/* Row: Status + ID (read-only) */}
+        <div className="flex flex-wrap gap-6">
+          <div className="flex-1 min-w-[200px]">
+            <label htmlFor="status" className="block text-xl font-bold mb-3">Status</label>
+            <input
+              required
+              type="text"
+              id="status"
+              value={status}
+              readOnly
+              className="w-full border-2 border-gray-300 px-3 py-3 rounded-lg cursor-not-allowed"
+            />
+          </div>
+
+          <div className="flex-1 min-w-[200px]">
+            <label htmlFor="id" className="block text-xl font-bold mb-3">ID Generated</label>
+            <input
+              required
+              type="text"
+              id="id"
+              value={IdGenerator}
+              readOnly
+              className="w-full border-2 border-gray-300 px-3 py-3 rounded-lg cursor-not-allowed"
+            />
+          </div>
+        </div>
+        <button type="submit" className="block mx-auto w-full text-lg bg-blue-500 font-medium text-white py-4 rounded-md hover:bg-blue-600 transition">Add Patient</button>
+      </form>
     </div>
+    </>
+
   );
 };
 

--- a/src/components/StaffDashboardComponent.jsx
+++ b/src/components/StaffDashboardComponent.jsx
@@ -1,5 +1,7 @@
+import { useContext } from "react";
 import { Link } from "react-router-dom";
-import { mockPatients } from "../data/mockData";
+import { PatientContext } from "../contexts/PatientContext";
+// import { mockPatients } from "../data/mockData";
 
 const statusStyles = {
   "Checked In": "bg-blue-100 text-blue-600",
@@ -10,6 +12,11 @@ const statusStyles = {
 };
 
 const StaffDashboardComponent = () => {
+
+  // Test -  Add this just to make the table update when someone add a patient
+  const {patients} = useContext(PatientContext);
+  const mockPatients = patients;
+
   return (
     <div className="min-h-screen bg-blue-50 px-4 py-10 relative">
       {/* Page Header */}
@@ -51,7 +58,7 @@ const StaffDashboardComponent = () => {
                   </td>
 
                   {/* Last Updated */}
-                  <td className="px-6 py-4">{patient.lastUpdated}</td>
+                  <td className="px-6 py-4">{new Date(patient.lastUpdated).toLocaleString()}</td>
 
                   {/* Actions */}
                   <td className="px-6 py-4 space-x-3">

--- a/src/contexts/PatientContext.jsx
+++ b/src/contexts/PatientContext.jsx
@@ -1,0 +1,3 @@
+import { createContext } from "react";
+
+export const PatientContext = createContext();

--- a/src/contexts/PatientProvider.jsx
+++ b/src/contexts/PatientProvider.jsx
@@ -1,0 +1,32 @@
+import { useEffect, useState } from 'react';
+import {mockPatients} from '../data/mockData.js'
+import { PatientContext } from './PatientContext'
+
+
+export const PatientProvider = ({ children }) => {
+    const [patients, setPatients] = useState([]);
+
+    useEffect(() => {
+        setPatients(mockPatients);
+    }, [])
+
+    const addPatient = (patientObj) => {
+        const newPatient = {
+            ...patientObj,
+            lastUpdated: new Date().toISOString()
+        };
+        setPatients(prev => [...prev, newPatient]);
+    };
+
+
+
+    const updatePatient = (id, updateInfo) => {
+        setPatients(prev => prev.map(p => (p.id === id ? {...p, ...updateInfo} : p)))
+    }
+
+  return (
+    <PatientContext.Provider value={{patients, addPatient, updatePatient}}>
+        {children}
+    </PatientContext.Provider>
+  )
+}

--- a/src/data/mockData.js
+++ b/src/data/mockData.js
@@ -2,43 +2,67 @@ export const STATUSES = ["Checked In", "Pre-Procedure", "In-Progress", "Recovery
 
 export const mockPatients = [
   {
-    id: "A312F2",
-    name: "John Smith",
-    procedure: "Knee Arthroscopy",
-    currentStatus: "In-Progress",
-    lastUpdated: "2025-07-21 14:30",
-    history: []
+    "id": "A312F2",
+    "name": "John Smith",
+    "phoneNum": "+1-555-101-0001",
+    "emailAddress": "john.smith@example.com",
+    "country": "USA",
+    "city": "Chicago",
+    "street": "456 Elm St",
+    "procedure": "Knee Arthroscopy",
+    "currentStatus": "In-Progress",
+    "lastUpdated": "2025-07-21 14:30",
+    "history": []
   },
   {
-    id: "B789G1",
-    name: "Jane Doe",
-    procedure: "Gallbladder Removal",
-    currentStatus: "Pre-Procedure",
-    lastUpdated: "2025-07-21 15:00",
-    history: []
+    "id": "B789G1",
+    "name": "Jane Doe",
+    "phoneNum": "+1-555-202-0002",
+    "emailAddress": "jane.doe@example.com",
+    "country": "USA",
+    "city": "Los Angeles",
+    "street": "789 Oak Ave",
+    "procedure": "Gallbladder Removal",
+    "currentStatus": "Pre-Procedure",
+    "lastUpdated": "2025-07-21 15:00",
+    "history": []
   },
   {
-    id: "C456H3",
-    name: "Peter Jones",
-    procedure: "Appendectomy",
-    currentStatus: "Recovery",
-    lastUpdated: "2025-07-21 13:15",
-    history: []
+    "id": "C456H3",
+    "name": "Peter Jones",
+    "phoneNum": "+1-555-303-0003",
+    "emailAddress": "peter.jones@example.com",
+    "country": "USA",
+    "city": "New York",
+    "street": "123 Main St",
+    "procedure": "Appendectomy",
+    "currentStatus": "Recovery",
+    "lastUpdated": "2025-07-21 13:15",
+    "history": []
   },
   {
-    id: "D123J4",
-    name: "Mary Williams",
-    procedure: "Heart Bypass",
-    currentStatus: "Complete",
-    lastUpdated: "2025-07-20 18:00",
-    history: []
+    "id": "D123J4",
+    "name": "Mary Williams",
+    "phoneNum": "+1-555-404-0004",
+    "emailAddress": "mary.williams@example.com",
+    "country": "USA",
+    "city": "Houston",
+    "street": "321 Pine Rd",
+    "procedure": "Heart Bypass",
+    "currentStatus": "Complete",
+    "lastUpdated": "2025-07-20 18:00",
   },
   {
-    id: "E789K5",
-    name: "David Brown",
-    procedure: "Hip Replacement",
-    currentStatus: "Checked In",
-    lastUpdated: "2025-07-21 11:45",
-    history: []
+    "id": "E789K5",
+    "name": "David Brown",
+    "phoneNum": "+1-555-505-0005",
+    "emailAddress": "david.brown@example.com",
+    "country": "USA",
+    "city": "Phoenix",
+    "street": "654 Cedar Ln",
+    "procedure": "Hip Replacement",
+    "currentStatus": "Checked In",
+    "lastUpdated": "2025-07-21 11:45",
+    "history": []
   }
 ];

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -4,13 +4,16 @@ import { BrowserRouter } from 'react-router-dom';
 import App from './App.jsx';
 import AuthProvider from './contexts/AuthProvider.jsx';
 import './index.css';
+import { PatientProvider } from './contexts/PatientProvider.jsx';
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>
     <AuthProvider>
-      <BrowserRouter>
-        <App />
-      </BrowserRouter>
+      <PatientProvider>           
+        <BrowserRouter>
+          <App />
+        </BrowserRouter>
+      </PatientProvider>
     </AuthProvider>
   </StrictMode>
 );


### PR DESCRIPTION
Add Patient Page with form, context integration, and ID generation

- Built the initial version of the Add Patient Page (based on current Figma design)
- Integrated PatientContext for global state management
- Added nanoid package to generate unique patient IDs
- Made 'Status' and 'ID' inputs read-only by default (starts as "Checked In")
- Updated Admin Dashboard to reflect newly added patients via context
- Extended mock data to include full patient details
- Redirects to Admin Dashboard after patient is added

<img width="1627" height="941" alt="Screenshot 2025-08-08 111944" src="https://github.com/user-attachments/assets/66465cd6-54a3-4613-8e1b-66e8067f8a94" />


